### PR TITLE
feat: add support for secret environment files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 The image is compatible with the following databases system :  `MySQL` (default) / `HSQLDB` / `PostgreSQL`
 
 - [Configuration options](#configuration-options)
+  - [Secret / Sensitive Environment Variables](#secret--sensitive-environment-variables)
   - [Add-ons](#add-ons)
   - [Patches](#patches)
   - [JVM](#jvm)
@@ -60,6 +61,54 @@ services:
       EXO_PATCHES_CATALOG_URL:
       EXO_ES_HOST: search
 ...
+```
+
+### Secret / Sensitive Environment Variables
+
+Some environment variables contain sensitive information such as passwords, API keys, or private keys. Hardcoding these values in your Docker commands or Compose files is **not recommended**. You can manage them securely using one of the following approaches:
+
+- **Docker secrets** (recommended for Swarm / Compose v3+), accessible inside the container as files.
+- **Environment files** (`.env`) with restricted permissions, referenced in Compose.
+- **_SEC_ / _FILE convention**, where variables can load values from files.
+
+#### `_SEC_` Prefix and `_FILE` Suffix
+
+For sensitive variables, you can use the `_SEC_` prefix in combination with `_FILE`. The container will automatically read the file content and populate the corresponding **regular environment variable**.
+
+**Example variables:**
+
+```text
+EXO_DB_PASSWORD
+EXO_SEC_DB_PASSWORD_FILE=/run/secrets/exo_db_password
+
+EXO_MAIL_SMTP_PASSWORD
+EXO_SEC_MAIL_SMTP_PASSWORD_FILE=/run/secrets/exo_mail_smtp_password
+
+EXO_JMX_PASSWORD
+EXO_SEC_JMX_PASSWORD_FILE=/run/secrets/exo_jmx_password
+
+EXO_REWARDS_WALLET_ADMIN_KEY
+EXO_SEC_REWARDS_WALLET_ADMIN_KEY_FILE=/run/secrets/exo_rewards_wallet_key
+
+EXO_CHAT_SERVER_PASSPHRASE
+EXO_SEC_CHAT_SERVER_PASSPHRASE_FILE=/run/secrets/exo_chat_passphrase
+```
+
+**How it works:**
+
+The container checks if the _SEC_ + _FILE variant exists.
+
+If yes, it reads the content of the file and sets the corresponding regular environment variable (without _SEC_ and _FILE) automatically.
+
+This allows your application to always use standard environment variable names, while keeping secrets securely stored in files.
+
+```bash
+# File /run/secrets/exo_db_password contains "supersecret"
+EXO_SEC_DB_PASSWORD_FILE=/run/secrets/exo_db_password
+```
+Inside the container, the following will be set automatically:
+```bash
+EXO_DB_PASSWORD="supersecret"
 ```
 
 ### Add-ons

--- a/README.md
+++ b/README.md
@@ -77,28 +77,39 @@ For sensitive variables, you can use the `_SEC_` prefix in combination with `_FI
 
 **Priority:** Direct environment variables take precedence over file-based secrets. If a regular variable is already set, the file-based secret will be ignored. This ensures explicit configuration always overrides mounted secrets.
 
+**Force override:** To force file-based secrets to override direct environment variables (e.g., for testing or debugging), use the `_FORCE` suffix:
+
+```bash
+EXO_SEC_DB_PASSWORD_FILE_FORCE=true
+```
+
 **Example variables:**
 
 ```text
 EXO_DB_PASSWORD
 EXO_SEC_DB_PASSWORD_FILE=/run/secrets/exo_db_password
+EXO_SEC_DB_PASSWORD_FILE_FORCE=true
 
 EXO_MAIL_SMTP_PASSWORD
 EXO_SEC_MAIL_SMTP_PASSWORD_FILE=/run/secrets/exo_mail_smtp_password
+EXO_SEC_MAIL_SMTP_PASSWORD_FILE_FORCE=true
 
 EXO_JMX_PASSWORD
 EXO_SEC_JMX_PASSWORD_FILE=/run/secrets/exo_jmx_password
+EXO_SEC_JMX_PASSWORD_FILE_FORCE=true
 
 EXO_REWARDS_WALLET_ADMIN_KEY
 EXO_SEC_REWARDS_WALLET_ADMIN_KEY_FILE=/run/secrets/exo_rewards_wallet_key
+EXO_SEC_REWARDS_WALLET_ADMIN_KEY_FILE_FORCE=true
 
 EXO_CHAT_SERVER_PASSPHRASE
 EXO_SEC_CHAT_SERVER_PASSPHRASE_FILE=/run/secrets/exo_chat_passphrase
+EXO_SEC_CHAT_SERVER_PASSPHRASE_FILE_FORCE=true
 ```
 
 **How it works:**
 
-The container checks if the _SEC_ + _FILE variant exists and if the corresponding regular environment variable is **not already set**. If both conditions are met, it reads the content of the file and sets the regular environment variable automatically.
+The container checks if the _SEC_ + _FILE variant exists and if the corresponding regular environment variable is **not already set** (unless `_FORCE` is enabled). If conditions are met, it reads the content of the file and sets the regular environment variable automatically.
 
 This allows eXo to always use standard environment variable names, while keeping secrets securely stored in files.
 
@@ -129,6 +140,22 @@ Inside the container, the direct value is preserved:
 
 ```bash
 EXO_DB_PASSWORD="custom-value"  # File content is ignored
+```
+
+**Example 3: Force override with _FORCE**
+
+```bash
+# Set direct variable and file reference with force
+EXO_DB_PASSWORD="custom-value"
+EXO_SEC_DB_PASSWORD_FILE=/run/secrets/exo_db_password
+EXO_SEC_DB_PASSWORD_FILE_FORCE=true
+# File /run/secrets/exo_db_password contains "supersecret"
+```
+
+Inside the container, the file value overrides:
+
+```bash
+EXO_DB_PASSWORD="supersecret"  # File content overrides due to _FORCE
 ```
 
 ### Add-ons

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Some environment variables contain sensitive information such as passwords, API 
 
 For sensitive variables, you can use the `_SEC_` prefix in combination with `_FILE`. The container will automatically read the file content and populate the corresponding **regular environment variable**.
 
+**Priority:** Direct environment variables take precedence over file-based secrets. If a regular variable is already set, the file-based secret will be ignored. This ensures explicit configuration always overrides mounted secrets.
+
 **Example variables:**
 
 ```text
@@ -96,19 +98,37 @@ EXO_SEC_CHAT_SERVER_PASSPHRASE_FILE=/run/secrets/exo_chat_passphrase
 
 **How it works:**
 
-The container checks if the _SEC_ + _FILE variant exists.
+The container checks if the _SEC_ + _FILE variant exists and if the corresponding regular environment variable is **not already set**. If both conditions are met, it reads the content of the file and sets the regular environment variable automatically.
 
-If yes, it reads the content of the file and sets the corresponding regular environment variable (without _SEC_ and _FILE) automatically.
+This allows eXo to always use standard environment variable names, while keeping secrets securely stored in files.
 
-This allows your application to always use standard environment variable names, while keeping secrets securely stored in files.
+**Example 1: Only file-based secret provided**
 
 ```bash
-# File /run/secrets/exo_db_password contains "supersecret"
+# Set only the file reference
 EXO_SEC_DB_PASSWORD_FILE=/run/secrets/exo_db_password
+# File /run/secrets/exo_db_password contains "supersecret"
 ```
+
 Inside the container, the following will be set automatically:
+
 ```bash
 EXO_DB_PASSWORD="supersecret"
+```
+
+**Example 2: Direct variable takes priority**
+
+```bash
+# Set both direct variable and file reference
+EXO_DB_PASSWORD="custom-value"
+EXO_SEC_DB_PASSWORD_FILE=/run/secrets/exo_db_password
+# File /run/secrets/exo_db_password contains "supersecret"
+```
+
+Inside the container, the direct value is preserved:
+
+```bash
+EXO_DB_PASSWORD="custom-value"  # File content is ignored
 ```
 
 ### Add-ons

--- a/bin/setenv-docker-customize.sh
+++ b/bin/setenv-docker-customize.sh
@@ -58,6 +58,24 @@ check_exo_properties() {
 }
 
 # -----------------------------------------------------------------------------
+# Load secrets from files if EXO_SEC_*_FILE environment variables are defined
+# -----------------------------------------------------------------------------
+for env_var in $(env | grep -E '^EXO_SEC_.*_FILE=' | cut -d= -f1); do
+  file_path="${!env_var}"
+  if [ -f "$file_path" ]; then
+    # Replace _SEC_ with _ to restore original variable name
+    target_var="${env_var/_SEC_/_}"
+    # Remove trailing _FILE
+    target_var="${target_var%_FILE}"
+    # Read the file content and export it as target variable
+    export "$target_var"="$(< "$file_path")"
+    echo "INFO: Loaded secret from ${file_path} into ${target_var}"
+  else
+    echo "WARNING: Secret file ${file_path} for ${env_var} does not exist!"
+  fi
+done
+
+# -----------------------------------------------------------------------------
 # Check configuration variables and add default values when needed
 # -----------------------------------------------------------------------------
 set +u		# DEACTIVATE unbound variable check

--- a/bin/setenv-docker-customize.sh
+++ b/bin/setenv-docker-customize.sh
@@ -59,17 +59,31 @@ check_exo_properties() {
 
 # -----------------------------------------------------------------------------
 # Load secrets from files if EXO_SEC_*_FILE environment variables are defined
+# Priority: Direct ENV > File (unless EXO_SEC_*_FILE_FORCE is set)
 # -----------------------------------------------------------------------------
 for env_var in $(env | grep -E '^EXO_SEC_.*_FILE=' | cut -d= -f1); do
   file_path="${!env_var}"
+  # Replace _SEC_ with _ to restore original variable name
+  target_var="${env_var/_SEC_/_}"
+  # Remove trailing _FILE
+  target_var="${target_var%_FILE}"
+  # Check if direct variable already exists
+  direct_var_exists=$(env | grep -E "^${target_var}=" || true)
+  # Check if force override is requested
+  force_var="${env_var}_FORCE"
+  force_override="${!force_var:-false}"
   if [ -f "$file_path" ]; then
-    # Replace _SEC_ with _ to restore original variable name
-    target_var="${env_var/_SEC_/_}"
-    # Remove trailing _FILE
-    target_var="${target_var%_FILE}"
-    # Read the file content and export it as target variable
-    export "$target_var"="$(< "$file_path")"
-    echo "INFO: Loaded secret from ${file_path} into ${target_var}"
+    if [ -n "$direct_var_exists" ] && [ "$force_override" != "true" ]; then
+      echo "INFO: ${target_var} already set via environment, skipping file ${file_path}"
+      echo "      (use ${force_var}=true to force override)"
+    else
+      if [ -n "$direct_var_exists" ]; then
+        echo "WARNING: Overriding existing ${target_var} with value from ${file_path} (forced)"
+      fi
+      # Read the file content and export it as target variable
+      export "$target_var"="$(< "$file_path")"
+      echo "INFO: Loaded secret from ${file_path} into ${target_var}"
+    fi
   else
     echo "WARNING: Secret file ${file_path} for ${env_var} does not exist!"
   fi


### PR DESCRIPTION
This commit introduces support for managing sensitive environment variables using secret files in the eXo Platform Docker image.

- Environment variables prefixed with EXO_SEC_ and suffixed with _FILE are read from the specified file paths.
- The file contents are exported as standard environment variables for use by the application.
- Enables secure handling of passwords, API keys, and private keys without hardcoding them in Docker commands or Compose files.

Example usage:
- EXO_SEC_DB_PASSWORD_FILE=/run/secrets/exo_db_password
- EXO_SEC_MAIL_SMTP_PASSWORD_FILE=/run/secrets/exo_mail_smtp_password