### PR TITLE
fix: remove Mysql addon when server configured with Postgresql DB - EXO-86224

### DIFF
--- a/test/docker-compose-71-pgsql.yml
+++ b/test/docker-compose-71-pgsql.yml
@@ -19,6 +19,7 @@ services:
     environment:
       EXO_DB_TYPE: pgsql
       EXO_ADDONS_LIST:
+      EXO_ADDONS_REMOVE_LIST: exo-jdbc-driver-mysql
       EXO_PATCHES_LIST:
       EXO_PATCHES_CATALOG_URL:
       EXO_ES_HOST: search


### PR DESCRIPTION
Internally, the system checks the classloader and considers that the platform will be using Mysql DB for persistence when it finds the Mysql driver class.  Thus to work properly with Postgresql , the Mysql driver addon shouldn't be installed in the platform.